### PR TITLE
ARM template claims provider api version property

### DIFF
--- a/deployment/ConnectedVehicleARMTemplate.json
+++ b/deployment/ConnectedVehicleARMTemplate.json
@@ -75,6 +75,12 @@
                 "description": "Claims provider uri which is used for platformAccount deployment."
             }
         },
+        "claimsProviderApiVersion": {
+            "type": "string",
+            "metadata": {
+                "description": "Claims provider API version which is used for platformAccount deployment."
+            }
+        },
         "logAnalyticsWorkspaceName": {
             "type": "string",
             "defaultValue": "[concat(uniqueString(resourceGroup().id), 'mcvplogs')]",
@@ -247,6 +253,9 @@
                     "claimsProviderUri": {
                         "value": "[parameters('claimsProviderUri')]"
                     },
+                    "claimsProviderApiVersion": {
+                        "value": "[parameters('claimsProviderApiVersion')]"
+                    },
                     "extensionsResourceId": {
                         "value": "[reference('McvpExtensions').outputs.mcvpextAFId.value]"
                     },
@@ -280,6 +289,9 @@
                             "type": "string"
                         },
                         "claimsProviderUri": {
+                            "type": "string"
+                        },
+                        "claimsProviderApiVersion": {
                             "type": "string"
                         },
                         "analyticsStorageAccountName": {
@@ -342,7 +354,8 @@
                                     }
                                 ],
                                 "claimsProvider": {
-                                    "baseUrl": "[parameters('claimsProviderUri')]"
+                                    "baseUrl": "[parameters('claimsProviderUri')]",
+                                    "apiVersion": "[parameters('claimsProviderApiVersion')]"
                                 }
                             },
                             "identity": {

--- a/deployment/ConnectedVehicleARMTemplate.json
+++ b/deployment/ConnectedVehicleARMTemplate.json
@@ -77,6 +77,11 @@
         },
         "claimsProviderApiVersion": {
             "type": "string",
+            "allowedValues": [
+                "2021-05-19",
+                "2022-01-30-preview"
+            ],
+            "defaultValue": "2021-05-19",
             "metadata": {
                 "description": "Claims provider API version which is used for platformAccount deployment."
             }

--- a/deployment/MultiExtensionCVPARMTemplate.json
+++ b/deployment/MultiExtensionCVPARMTemplate.json
@@ -59,6 +59,11 @@
         },
         "claimsProviderUri": {
             "type": "string",
+            "allowedValues": [
+                "2021-05-19",
+                "2022-01-30-preview"
+            ],
+            "defaultValue": "2021-05-19",
             "metadata": {
                 "description": "Claims provider uri which is used for platformAccount deployment."
             }

--- a/deployment/MultiExtensionCVPARMTemplate.json
+++ b/deployment/MultiExtensionCVPARMTemplate.json
@@ -62,6 +62,12 @@
             "metadata": {
                 "description": "Claims provider uri which is used for platformAccount deployment."
             }
+        },
+        "claimsProviderApiVersion": {
+            "type": "string",
+            "metadata": {
+                "description": "Claims provider API version which is used for platformAccount deployment."
+            }
         }
     },
     "resources": [
@@ -94,6 +100,9 @@
                     },
                     "claimsProviderUri": {
                         "value": "[parameters('claimsProviderUri')]"
+                    },
+                    "claimsProviderApiVersion": {
+                        "value": "[parameters('claimsProviderApiVersion')]"
                     },
                     "extensionsResourceIds": {
                         "value": "[parameters('extensionResourceIds')]"
@@ -128,6 +137,9 @@
                             "type": "array"
                         },
                         "claimsProviderUri": {
+                            "type": "string"
+                        },
+                        "claimsProviderApiVersion": {
                             "type": "string"
                         },
                         "analyticsStorageAccountName": {
@@ -194,7 +206,8 @@
                                     }
                                 ],
                                 "claimsProvider": {
-                                    "baseUrl": "[parameters('claimsProviderUri')]"
+                                    "baseUrl": "[parameters('claimsProviderUri')]",
+                                    "apiVersion": "[parameters('claimsProviderApiVersion')]"
                                 }
                             },
                             "identity": {


### PR DESCRIPTION
Updated sample ARM templates to set Claims Provider API version property. Currently supported versions are 
2021-05-19 (default version if the property is not explicitly set)
2022-01-30-preview (new version)